### PR TITLE
Update proxy.js

### DIFF
--- a/passthrough-proxy-with-keyvalidation/api/controllers/proxy.js
+++ b/passthrough-proxy-with-keyvalidation/api/controllers/proxy.js
@@ -33,7 +33,7 @@ function verifyAPIKey(req, next) {
       debug('error: %j', err);
 
       // only return error to client on invalid key
-      if (err.code === 'oauth.v2.InvalidApiKey') {
+      if (err.code === 'access_denied') {
         return next(err);
       }
     }


### PR DESCRIPTION
err.code does not return "oauth.v2.InvalidApiKey" it returns "access_denied". 

Debug log:
 apigee Verify response: {"error":"oauth.v2.InvalidApiKey","error_description":"com.apigee.oauth.v2.OauthAdaptorVerificationException{ code = oauth.v2.InvalidApiKey, message = Invalid ApiKey, associated contexts = []}"} +391ms
  proxy error: {"code":"access_denied","statusCode":403} +2s